### PR TITLE
Use relative path for finding current_outdir.conf

### DIFF
--- a/scripts/aste/common.py
+++ b/scripts/aste/common.py
@@ -18,8 +18,7 @@ import bbsweeplib as bbs
 
 ## output directories
 #outdir    = 'out/'
-script_dir = os.path.dirname(os.path.abspath(__file__))
-current_outdir = os.path.join(script_dir, 'current_outdir.conf')
+current_outdir = './current_outdir.conf'
 
 with open(current_outdir) as f:
     outdir = f.readline().strip()


### PR DESCRIPTION
This PR uses relative path for finding `current_outdir.conf` so that users can use the analysis scripts from anywhere like:

```
python scripts/aste/Configure.py /path/to/rawdata /path/to/outdir
python scripts/aste/FitSweep.py
python scripts/aste/SaveFits.py
```